### PR TITLE
remove obsolete variables, rename page to cmfMainContent. fix #2

### DIFF
--- a/Controller/ContentController.php
+++ b/Controller/ContentController.php
@@ -97,10 +97,7 @@ class ContentController
     protected function getParams(Request $request, $contentDocument)
     {
         return array(
-            'title' => $contentDocument->getTitle(),
-            'path' => $contentDocument->getPath(),
-            'page' => $contentDocument,
-            'url' => $request->getPathInfo(),
+            'cmfMainContent' => $contentDocument,
         );
     }
 }


### PR DESCRIPTION
rename the page variable. the title is actually not needed. the knowledge what property contains the title belongs into the template, not into the controller.
