### PR TITLE
Fix replacing multilang admin class

### DIFF
--- a/DependencyInjection/SymfonyCmfContentExtension.php
+++ b/DependencyInjection/SymfonyCmfContentExtension.php
@@ -46,11 +46,11 @@ class SymfonyCmfContentExtension extends Extension
         if ('auto' === $config['use_sonata_admin'] && !isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
             return;
         }
+        
+        $loader->load($prefix . 'admin.xml');
 
         if (isset($config['admin_class'])) {
-            $container->setParameter($this->getAlias() . $prefix. '.admin_class', $config['admin_class']);
+            $container->setParameter($this->getAlias() . '.' . $prefix . 'admin_class', $config['admin_class']);
         }
-
-        $loader->load($prefix.'admin.xml');
     }
 }


### PR DESCRIPTION
FIx wrong order: Set params after loading admin xml; Fix Wrong dot concatination

replaces https://github.com/symfony-cmf/ContentBundle/pull/11
