### PR TITLE
Apply change concerning removed MinimalRoute class

### DIFF
--- a/Admin/StaticContentAdmin.php
+++ b/Admin/StaticContentAdmin.php
@@ -61,7 +61,7 @@ class StaticContentAdmin extends Admin
                     array(
                         'edit' => 'inline',
                         'inline' => 'table',
-                        'admin_code' => 'symfony_cmf_routing_extra.minimal_route_admin',
+                        'admin_code' => 'symfony_cmf_routing_extra.route_admin',
                     ))
             ->end()
             ->with('Menu')


### PR DESCRIPTION
To be merged after https://github.com/symfony-cmf/RoutingExtraBundle/pull/77
