### PR TITLE
removed obsolete admin_code attribute

### DIFF
--- a/Admin/StaticContentAdmin.php
+++ b/Admin/StaticContentAdmin.php
@@ -23,23 +23,6 @@ class StaticContentAdmin extends Admin
      */
     protected $contentRoot;
 
-    /**
-     * Service name of the sonata_type_collection service to embed
-     *
-     * @var string
-     */
-    protected $menuAdminCode;
-
-    /**
-     * Configure the service name (admin_code) of the admin service for the embedded menu nodes
-     *
-     * @param $adminCode
-     */
-    public function setEmbeddedMenuAdmin($adminCode)
-    {
-        $this->menuAdminCode = $adminCode;
-    }
-
     protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
@@ -61,7 +44,6 @@ class StaticContentAdmin extends Admin
                     array(
                         'edit' => 'inline',
                         'inline' => 'table',
-                        'admin_code' => 'cmf_routing.route_admin',
                     ))
             ->end()
             ->with('form.group_menus')
@@ -74,7 +56,6 @@ class StaticContentAdmin extends Admin
                     array(
                         'edit' => 'inline',
                         'inline' => 'table',
-                        'admin_code' => $this->menuAdminCode,
                     ))
             ->end()
             ->with('form.group_general')

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -22,10 +22,6 @@
             <call method="setContentRoot">
                 <argument>%cmf_content.content_basepath%</argument>
             </call>
-
-            <call method="setEmbeddedMenuAdmin">
-                <argument>cmf_menu.admin</argument>
-            </call>
         </service>
     </services>
 </container>

--- a/Resources/config/multilang.admin.xml
+++ b/Resources/config/multilang.admin.xml
@@ -23,10 +23,6 @@
             <call method="setContentRoot">
                 <argument>%cmf_content.content_basepath%</argument>
             </call>
-
-            <call method="setEmbeddedMenuAdmin">
-                <argument>cmf_menu.multilang.admin</argument>
-            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
after https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/138 is merged   the admin_code attribute is no longer required.
