### PR TITLE
Updated menu reference to "content" instead of "weakContent"

### DIFF
--- a/Resources/config/doctrine/StaticContent.phpcr.xml
+++ b/Resources/config/doctrine/StaticContent.phpcr.xml
@@ -25,7 +25,7 @@
         <field name="publishStartDate" type="date"/>
         <field name="publishEndDate" type="date"/>
         <referrers name="routes" referring-document="Symfony\Cmf\Bundle\RoutingBundle\Document\Route" referenced-by="routeContent" cascade="persist"/>
-        <referrers name="menus" referring-document="Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode" referenced-by="weakContent" cascade="persist"/>
+        <referrers name="menus" referring-document="Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode" referenced-by="content" cascade="persist"/>
     </document>
 
 </doctrine-mapping>


### PR DESCRIPTION
Update in relation to: https://github.com/symfony-cmf/MenuBundle/pull/97
