### PR TITLE
improve standalone runnability as noted in #63

### DIFF
--- a/CmfContentBundle.php
+++ b/CmfContentBundle.php
@@ -17,7 +17,8 @@ class CmfContentBundle extends Bundle
                         realpath(__DIR__ . '/Resources/config/doctrine-model') => 'Symfony\Cmf\Bundle\ContentBundle\Model',
                         realpath(__DIR__ . '/Resources/config/doctrine-phpcr') => 'Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr',
                     ),
-                    array('cmf_content.manager_name')
+                    array('cmf_content.manager_name'),
+                    'cmf_content.backend_type_phpcr'
                 )
             );
         }

--- a/DependencyInjection/CmfContentExtension.php
+++ b/DependencyInjection/CmfContentExtension.php
@@ -26,6 +26,8 @@ class CmfContentExtension extends Extension
 
     public function loadPhpcr($config, XmlFileLoader $loader, ContainerBuilder $container)
     {
+        $container->setParameter($this->getAlias() . '.backend_type_phpcr', true);
+
         $keys = array(
             'document_class' => 'document.class',
             'manager_name' => 'manager_name',

--- a/Tests/WebTest/Admin/StaticContentAdminTest.php
+++ b/Tests/WebTest/Admin/StaticContentAdminTest.php
@@ -45,6 +45,7 @@ class StaticContentAdminTest extends BaseTestCase
         $form[$uniqId.'[parent]'] = '/test/contents';
         $form[$uniqId.'[name]'] = 'foo-test';
         $form[$uniqId.'[title]'] = 'Foo Test';
+        $form[$uniqId.'[body]'] = 'Foo Test';
 
         $this->client->submit($form);
         $res = $this->client->getResponse();

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.2",
-        "symfony-cmf/core-bundle": "~1.0.0-RC1",
-        "doctrine/phpcr-bundle": "1.0.*",
-        "doctrine/phpcr-odm": "1.0.*"
+        "symfony-cmf/core-bundle": "~1.0.0-RC1"
     },
     "require-dev": {
         "symfony-cmf/testing": "1.0.*",
+        "doctrine/phpcr-bundle": "1.0.*",
+        "doctrine/phpcr-odm": "1.0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "1.0.*",
         "symfony-cmf/menu-bundle": "1.0.*",
         "symfony-cmf/routing-bundle": "1.1.*",
@@ -30,7 +30,10 @@
     "suggest": {
         "symfony-cmf/menu-bundle": "Have editable menus for content",
         "symfony-cmf/routing-bundle": "Have editable routes for content",
-        "friendsofsymfony/rest-bundle": "Improved handling for different output formats"
+        "friendsofsymfony/rest-bundle": "Improved handling for different output formats",
+        "doctrine/phpcr-odm": "To persist content with the PHP content repository",
+        "doctrine/phpcr-bundle": "To integrate PHPCR-ODM with Symfony",
+        "sonata-project/doctrine-phpcr-admin-bundle": "To provide admin interfaces for the content"
     },
     "autoload":{
         "psr-0":{


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #63 |
| License | MIT |
| Doc PR | - |

This cleans up dependencies. If you want to use ContentBundle without MenuBundle, you should not enable the phpcr-odm as that would try to create a proxy for StaticContent which implements an interface from MenuBundle.

For all its worth, you could extend BaseStaticContent and copy the mappings into your bundle and make sure they all apply. Or simply use a custom document that you map yourself.

@fazy: would you mind checking if we lose other functionality if you disable phpcr? as in

```
cmf_content:
  persistence:
    phpcr:
      enabled: false
```

if this is not workable, we might need allow to separatly configure the parameter that decides if the mapping compiler pass gets activated or not.
