### PR TITLE
Use Schema.org WebPage type for StaticContent

### DIFF
--- a/Resources/rdf-mappings/Symfony.Cmf.Bundle.ContentBundle.Doctrine.Phpcr.StaticContent.xml
+++ b/Resources/rdf-mappings/Symfony.Cmf.Bundle.ContentBundle.Doctrine.Phpcr.StaticContent.xml
@@ -1,12 +1,11 @@
 <type
-    xmlns:sioc="http://rdfs.org/sioc/ns#"
-    xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-    typeof="sioc:Post"
->
+        xmlns:sc="http://schema.org/"
+        xmlns:cw="http://schema.org/CreativeWork"
+        typeof="sc:WebPage"
+        >
     <children>
-        <property property="dcterms:title" identifier="title" tag-name="h1"/>
-        <property property="sioc:content" identifier="body" />
-        <collection rel="skos:related" identifier="tags" tag-name="ul" />
+        <property property="cw:headline" identifier="title" tag-name="h1"/>
+        <property property="cw:text" identifier="body" />
+        <property property="cw:keywords" identifier="tags" tag-name="ul"/>
     </children>
 </type>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no (except for consumers of the rdfa data) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7 |
| License | MIT |

IMHO, the most adapted type is WebPage.
