### PR TITLE
Removed references to removed template

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
 
         $treeBuilder->root('cmf_content')
             ->children()
-                ->scalarNode('default_template')->defaultNull()->end()
+                ->scalarNode('default_template')->end()
                 ->arrayNode('persistence')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,7 +4,7 @@
 
     <parameters>
         <parameter key="cmf_content.document.class">Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent</parameter>
-        <parameter key="cmf_content.default_template">CmfContentBundle:StaticContent:index.html.twig</parameter>
+        <parameter key="cmf_content.default_template">null</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
The template was removedin #5, but the settings still defaults to this non-existing template.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
