### PR TITLE
remove unneeded hardcoded route name from admin

### DIFF
--- a/Admin/StaticContentAdmin.php
+++ b/Admin/StaticContentAdmin.php
@@ -20,8 +20,6 @@ use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent;
 
 class StaticContentAdmin extends Admin
 {
-    protected $baseRouteName = 'cmf_content_staticcontent';
-    protected $baseRoutePattern = '/cmf/content/staticcontent';
     protected $translationDomain = 'CmfContentBundle';
 
     public function getNewInstance()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

These assignments are no longer needed. If we have them, an admin extending this class must overwrite the fields.
