### PR TITLE
Add Valid constraint to routes and menuNodes attributes

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -7,6 +7,14 @@
     <class name="Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent">
         <constraint name="Doctrine\Bundle\PHPCRBundle\Validator\Constraints\ValidPhpcrOdm" />
 
+        <property name="routes">
+            <constraint name="Valid" />
+        </property>
+
+        <property name="menuNodes">
+            <constraint name="Valid" />
+        </property>
+        
         <property name="title">
             <constraint name="NotBlank" />
         </property>


### PR DESCRIPTION
When submitting the `StaticContent` admin form, the routes and menus are not validated. This PR fixes it.

Another solution would be to add dynamic validation directly in the admin form, so it's applied only there.
