### PR TITLE
Use ChildInterface

### DIFF
--- a/Admin/StaticContentAdmin.php
+++ b/Admin/StaticContentAdmin.php
@@ -24,20 +24,6 @@ class StaticContentAdmin extends Admin
 {
     protected $translationDomain = 'CmfContentBundle';
 
-    public function getNewInstance()
-    {
-        /** @var $new StaticContent */
-        $new = parent::getNewInstance();
-        if ($this->hasRequest()) {
-            $parentId = $this->getRequest()->query->get('parent');
-            if (null !== $parentId) {
-                $new->setParent($this->getModelManager()->find(null, $parentId));
-            }
-        }
-
-        return $new;
-    }
-
     public function getExportFormats()
     {
         return array();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* **2014-03-24**: setParent() and getParent() are now deprecated.
+  Use setParentDocument() and getParentDocument() instead.
+  Moreover, you should now enable the ChildExtension from the CoreBundle.
+
 1.1.1
 -----
 

--- a/Doctrine/Phpcr/StaticContent.php
+++ b/Doctrine/Phpcr/StaticContent.php
@@ -42,12 +42,34 @@ class StaticContent extends ModelStaticContent
      */
     protected $node;
 
+    /**
+     * @deprecated Use setParentDocument instead.
+     */
     public function setParent($parent)
+    {
+        $this->setParentDocument($parent);
+    }
+
+    /**
+     * @deprecated Use getParentDocument instead.
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setParentDocument($parent)
     {
         $this->parent = $parent;
     }
 
-    public function getParent()
+    /**
+     * {@inheritDoc}
+     */
+    public function getParentDocument()
     {
         return $this->parent;
     }

--- a/Doctrine/Phpcr/StaticContentBase.php
+++ b/Doctrine/Phpcr/StaticContentBase.php
@@ -14,8 +14,9 @@ namespace Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr;
 
 use PHPCR\NodeInterface;
 use Symfony\Cmf\Bundle\ContentBundle\Model\StaticContentBase as ModelStaticContentBase;
+use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
 
-class StaticContentBase extends ModelStaticContentBase
+class StaticContentBase extends ModelStaticContentBase implements ChildInterface
 {
     /**
      * PHPCR parent document
@@ -38,12 +39,34 @@ class StaticContentBase extends ModelStaticContentBase
      */
     protected $node;
 
+    /**
+     * @deprecated Use setParentDocument instead.
+     */
     public function setParent($parent)
+    {
+        $this->setParentDocument($parent);
+    }
+
+    /**
+     * @deprecated Use getParentDocument instead.
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setParentDocument($parent)
     {
         $this->parent = $parent;
     }
 
-    public function getParent()
+    /**
+     * {@inheritDoc}
+     */
+    public function getParentDocument()
     {
         return $this->parent;
     }

--- a/Tests/Functional/Doctrine/Phpcr/StaticContentTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/StaticContentTest.php
@@ -38,7 +38,7 @@ class StaticContentTest extends BaseTestCase
         $content = new StaticContent;
         $refl = new \ReflectionClass($content);
 
-        $content->setParent($this->base);
+        $content->setParentDocument($this->base);
 
         foreach ($data as $key => $value) {
             $refl = new \ReflectionClass($content);

--- a/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
@@ -40,14 +40,14 @@ class LoadContentData implements FixtureInterface, DependentFixtureInterface
         $content->setName('content-1');
         $content->setTitle('Content 1');
         $content->setBody('Content 1');
-        $content->setParent($contentRoot);
+        $content->setParentDocument($contentRoot);
         $manager->persist($content);
 
         $content = new StaticContent;
         $content->setName('content-2');
         $content->setTitle('Content 2');
         $content->setBody('Content 2');
-        $content->setParent($contentRoot);
+        $content->setParentDocument($contentRoot);
         $manager->persist($content);
 
         $manager->flush();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/symfony-cmf/issues/188 |
| License | MIT |

See https://github.com/symfony-cmf/symfony-cmf/issues/188.

I deprecated the `getParent`/`setParent` methods in favor of the `ChildInterface` ones. If it's ok, I'll do the same for the other bundles.
