### PR TITLE
remove deprecated class from testing

### DIFF
--- a/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadContentData.php
@@ -16,19 +16,14 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\ODM\PHPCR\Document\Generic;
+use PHPCR\Util\NodeHelper;
 use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent;
 
-class LoadContentData implements FixtureInterface, DependentFixtureInterface
+class LoadContentData implements FixtureInterface
 {
-    public function getDependencies()
-    {
-        return array(
-            'Symfony\Cmf\Component\Testing\DataFixtures\PHPCR\LoadBaseData',
-        );
-    }
-
     public function load(ObjectManager $manager)
     {
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
         $root = $manager->find(null, '/test');
 
         $contentRoot = new Generic;


### PR DESCRIPTION
removed deprecated classes as described in: symfony-cmf/symfony-cmf#191

But got an strange error in my local test, hope it just a local version problem.
