### PR TITLE
register doctrine alias mapper pass

### DIFF
--- a/CmfContentBundle.php
+++ b/CmfContentBundle.php
@@ -27,7 +27,8 @@ class CmfContentBundle extends Bundle
                         realpath(__DIR__ . '/Resources/config/doctrine-phpcr') => 'Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr',
                     ),
                     array('cmf_content.manager_name'),
-                    'cmf_content.backend_type_phpcr'
+                    'cmf_content.backend_type_phpcr',
+                    array('CmfContentBundle' => 'Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr')
                 )
             );
         }


### PR DESCRIPTION
 to support CmfContentBundle:StaticContent shortcut

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | travis |
| Fixed tickets | https://github.com/symfony-cmf/symfony-cmf/issues/204 |
| License | MIT |
| Doc PR | - |
