### PR TITLE
Extract StaticContentType from StaticContentAdmin

### DIFF
--- a/Admin/StaticContentAdmin.php
+++ b/Admin/StaticContentAdmin.php
@@ -9,29 +9,18 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Symfony\Cmf\Bundle\ContentBundle\Admin;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
-use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\Form\Type\StaticContentType;
 use Symfony\Cmf\Bundle\ContentBundle\Model\StaticContentBase;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 class StaticContentAdmin extends Admin
 {
     protected $translationDomain = 'CmfContentBundle';
-
-    private $ivoryCkeditor = array();
-
-    public function setIvoryCkeditor($config)
-    {
-        $this->ivoryCkeditor = (array) $config;
-    }
 
     public function getExportFormats()
     {
@@ -48,20 +37,16 @@ class StaticContentAdmin extends Admin
 
     protected function configureFormFields(FormMapper $formMapper)
     {
+        $builder = $formMapper->getFormBuilder()->getFormFactory()->createBuilder(StaticContentType::class, null, [
+            'readonly_parent_document' => (bool) $this->id($this->getSubject()),
+        ]);
+
         $formMapper
             ->with('form.group_general')
-                ->add('parentDocument', TreeModelType::class, array(
-                    'root_node' => $this->getRootPath(),
-                    'choice_list' => array(),
-                    'select_root_node' => true,
-                ))
-                ->add('name', TextType::class)
-                ->add('title', TextType::class)
-                ->add(
-                    'body',
-                    $this->ivoryCkeditor ? CKEditorType::class : TextareaType::class,
-                    $this->ivoryCkeditor
-                )
+                ->add($builder->get('parentDocument'))
+                ->add($builder->get('name'))
+                ->add($builder->get('title'))
+                ->add($builder->get('body'))
             ->end()
         ;
     }

--- a/Doctrine/Phpcr/Form/Type/StaticContentType.php
+++ b/Doctrine/Phpcr/Form/Type/StaticContentType.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\Form\Type;
+
+use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\DocumentToPathTransformer;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent;
+use Symfony\Cmf\Bundle\ContentBundle\Form\Type\StaticContentType as ModelStaticContentType;
+use Symfony\Cmf\Bundle\TreeBrowserBundle\Form\Type\TreeSelectType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StaticContentType extends AbstractType
+{
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var string
+     */
+    private $contentBasePath;
+
+    /**
+     * @param DocumentManager $documentManager
+     * @param string          $contentBasePath
+     */
+    public function __construct(DocumentManager $documentManager, $contentBasePath)
+    {
+        $this->documentManager = $documentManager;
+        $this->contentBasePath = $contentBasePath;
+    }
+
+    /**
+     * Builds the form.
+     *
+     * @see FormTypeInterface::buildForm()
+     *
+     * Available options:
+     *     - readonly_parent_document bool use a disabled text field for parentDocument
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('name', TextType::class);
+
+        if ($options['readonly_parent_document']) {
+            $builder->add('parentDocument', TextType::class, [
+                'disabled' => true,
+            ]);
+        } else {
+            $builder->add('parentDocument', TreeSelectType::class, [
+                'widget' => 'browser',
+                'root_node' => $this->contentBasePath,
+            ]);
+        }
+
+        $builder->get('parentDocument')
+            ->addModelTransformer(new DocumentToPathTransformer($this->documentManager))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => StaticContent::class,
+            'readonly_parent_document' => false,
+        ]);
+        $resolver->addAllowedTypes('readonly_parent_document', 'bool');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return ModelStaticContentType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'cmf_content_phpcr_static_content';
+    }
+}

--- a/Form/Extension/IvoryCKEditorExtension.php
+++ b/Form/Extension/IvoryCKEditorExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Form\Extension;
+
+use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use Symfony\Cmf\Bundle\ContentBundle\Form\Type\StaticContentType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class IvoryCKEditorExtension extends AbstractTypeExtension
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @param array $options CKEditorType options
+     *
+     * @see CKEditorType
+     */
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('body', CKEditorType::class, $this->options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return StaticContentType::class;
+    }
+}

--- a/Form/Type/StaticContentType.php
+++ b/Form/Type/StaticContentType.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Form\Type;
+
+use Symfony\Cmf\Bundle\ContentBundle\Model\StaticContent;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StaticContentType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('title', TextType::class)
+            ->add('body', TextareaType::class)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => StaticContent::class,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'cmf_content_model_static_content';
+    }
+}

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -18,10 +18,6 @@
             <call method="setRootPath">
                 <argument>%cmf_content.persistence.phpcr.content_basepath%</argument>
             </call>
-
-            <call method="setIvoryCkeditor">
-                <argument>%cmf_content.ivory_ckeditor.config%</argument>
-            </call>
         </service>
     </services>
 </container>

--- a/Resources/config/forms-phpcr.xml
+++ b/Resources/config/forms-phpcr.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="cmf_content.doctrine.phpcr.form.type.static_content"
+            class="Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\Form\Type\StaticContentType">
+
+            <argument type="service" id="doctrine_phpcr.odm.document_manager" />
+            <argument>%cmf_content.persistence.phpcr.content_basepath%</argument>
+            <tag name="form.type" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/ivory-ckeditor.xml
+++ b/Resources/config/ivory-ckeditor.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="cmf_content.form.extension.ivory_ckeditor"
+            class="Symfony\Cmf\Bundle\ContentBundle\Form\Extension\IvoryCKEditorExtension">
+            <argument>%cmf_content.ivory_ckeditor.config%</argument>
+            <tag name="form.type_extension"
+                extended_type="Symfony\Cmf\Bundle\ContentBundle\Form\Type\StaticContentType"
+            />
+        </service>
+    </services>
+</container>

--- a/Tests/Unit/Doctrine/Phpcr/Form/Type/StaticContentTypeTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/Form/Type/StaticContentTypeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Tests\Unit\Doctrine\Phpcr\Form\Type;
+
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Document\Generic;
+use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\Form\Type\StaticContentType;
+use Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent;
+use Symfony\Cmf\Bundle\TreeBrowserBundle\Form\Type\TreeSelectType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class StaticContentTypeTest extends TypeTestCase
+{
+    private $documentManager;
+
+    protected function setUp()
+    {
+        $this->documentManager = $this->getMockBuilder(DocumentManager::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
+        $type = new StaticContentType($this->documentManager, '/cms/content');
+
+        return [
+            new PreloadedExtension([$type], []),
+        ];
+    }
+
+    public function testSubmitValidData()
+    {
+        $data = [
+            'name' => 'hello-world',
+            'parentDocument' => '/cms/content',
+        ];
+
+        $document = $this->getMock(Generic::class);
+
+        $this->documentManager->expects($this->once())
+            ->method('find')
+            ->with(null, $data['parentDocument'])
+            ->will($this->returnValue($document));
+
+        $form = $this->factory->create(StaticContentType::class);
+
+        $form->submit($data);
+
+        $object = new StaticContent();
+        $object->setName($data['name']);
+        $object->setParentDocument($document);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+    }
+
+    public function testReadonlyParentDocument()
+    {
+        $builder = $this->factory->createBuilder(StaticContentType::class, null, [
+            'readonly_parent_document' => true,
+        ]);
+
+        $this->assertInstanceof(
+            TextType::class,
+            $builder->get('parentDocument')->getForm()->getConfig()->getType()->getInnerType()
+        );
+        $this->assertTrue($builder->get('parentDocument')->getDisabled());
+    }
+
+    public function testWritableParentDocument()
+    {
+        $form = $this->factory->create(StaticContentType::class);
+        $this->assertInstanceof(
+            TreeSelectType::class,
+            $form->get('parentDocument')->getConfig()->getType()->getInnerType()
+        );
+    }
+}

--- a/Tests/Unit/Form/Extension/IvoryCKEditorExtensionTest.php
+++ b/Tests/Unit/Form/Extension/IvoryCKEditorExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Tests\Unit\Form\Extension;
+
+use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use Ivory\CKEditorBundle\Model\PluginManagerInterface;
+use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
+use Ivory\CKEditorBundle\Model\TemplateManagerInterface;
+use Ivory\CKEditorBundle\Model\StylesSetManagerInterface;
+use Symfony\Cmf\Bundle\ContentBundle\Form\Type\StaticContentType;
+use Symfony\Cmf\Bundle\ContentBundle\Form\Extension\IvoryCKEditorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class IvoryCKEditorExtensionTest extends TypeTestCase
+{
+    protected function getExtensions()
+    {
+        $type = new CKEditorType(
+            $this->getMock(ConfigManagerInterface::class),
+            $this->getMock(PluginManagerInterface::class),
+            $this->getMock(StylesSetManagerInterface::class),
+            $this->getMock(TemplateManagerInterface::class)
+        );
+        $extension = new IvoryCKEditorExtension([]);
+
+        return [
+            new PreloadedExtension([$type], [StaticContentType::class => [$extension]]),
+        ];
+    }
+
+    public function testOverrideBody()
+    {
+        $form = $this->factory->create(StaticContentType::class);
+        $this->assertInstanceOf(CKEditorType::class, $form->get('body')->getConfig()->getType()->getInnerType());
+    }
+}

--- a/Tests/Unit/Form/Type/StaticContentTypeTest.php
+++ b/Tests/Unit/Form/Type/StaticContentTypeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\ContentBundle\Tests\Unit\Form\Type;
+
+use Symfony\Cmf\Bundle\ContentBundle\Form\Type\StaticContentType;
+use Symfony\Cmf\Bundle\ContentBundle\Model\StaticContent;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class StaticContentTypeTest extends TypeTestCase
+{
+    public function testSubmitValidData()
+    {
+        $data = [
+            'title' => 'Hello World!',
+            'body' => '<p>Lorem ipsum dolor sit amet.</p>',
+        ];
+
+        $form = $this->factory->create(StaticContentType::class);
+
+        $form->submit($data);
+
+        $object = new StaticContent();
+        $object->setTitle($data['title']);
+        $object->setBody($data['body']);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "doctrine/phpcr-odm": "^2.0@dev",
         "symfony-cmf/testing": "^2.0@dev",
         "sonata-project/doctrine-phpcr-admin-bundle": "^2.0@dev",
-        "symfony/monolog-bundle": "^2.8|^3.0"
+        "sonata-project/admin-bundle": "^3.6",
+        "symfony/monolog-bundle": "^2.8|^3.0",
+        "egeloen/ckeditor-bundle": "^4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -31,6 +33,7 @@
         "doctrine/phpcr-odm": "To persist content with the PHP content repository",
         "doctrine/phpcr-bundle": "To integrate PHPCR-ODM with Symfony",
         "sonata-project/doctrine-phpcr-admin-bundle": "To provide admin interfaces for the content (^1.1)",
+        "sonata-project/admin-bundle": "To provide admin interfaces for the content (^3.6)",
         "egeloen/ckeditor-bundle": "to provide a CKEditor in the admin interface"
     },
     "autoload": {


### PR DESCRIPTION
To ease the extraction of sonata admin class, it was decided that the form used to edit staticContent should be extracted from the admin class.

I also changed a bit options about IvoryCkEditor to allow using IvoryCkEditor with default options.

## Progress

### Todo
- [x] parentDocument field
- [x] TreeSelectType assets
- [x] allow to use TreeSelectType browser widget
- [x] fix fields ordering
- [x] tests
- [x] history rewrite
- [x] write `Form/Extension/CKEditorExtension` tests
- [x] squash commits

### Blockers
- [x] https://github.com/symfony-cmf/tree-browser-bundle/pull/112
- [x] https://github.com/sonata-project/SonataAdminBundle/pull/4101