### PR TITLE
Clear configuration options & their processing

### DIFF
--- a/src/DependencyInjection/CmfContentExtension.php
+++ b/src/DependencyInjection/CmfContentExtension.php
@@ -69,7 +69,6 @@ class CmfContentExtension extends Extension
         $container->setParameter($this->getAlias().'.backend_type_phpcr', true);
 
         $keys = array(
-            'document_class' => 'document.class',
             'manager_name' => 'manager_name',
             'content_basepath' => 'content_basepath',
         );

--- a/src/DependencyInjection/CmfContentExtension.php
+++ b/src/DependencyInjection/CmfContentExtension.php
@@ -64,18 +64,18 @@ class CmfContentExtension extends Extension
         return isset($bundles['IvoryCKEditorBundle']);
     }
 
-    public function loadPhpcr($config, XmlFileLoader $loader, ContainerBuilder $container)
+    public function loadPhpcr(array $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
         $container->setParameter($this->getAlias().'.backend_type_phpcr', true);
 
         $keys = array(
-            'manager_name' => 'manager_name',
-            'content_basepath' => 'content_basepath',
+            'manager_name',
+            'content_basepath',
         );
 
-        foreach ($keys as $sourceKey => $targetKey) {
-            if (isset($config[$sourceKey])) {
-                $container->setParameter($this->getAlias().'.persistence.phpcr.'.$targetKey, $config[$sourceKey]);
+        foreach ($keys as $key) {
+            if (isset($config[$key])) {
+                $container->setParameter($this->getAlias().'.persistence.phpcr.'.$key, $config[$sourceKey]);
             }
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->canBeEnabled()
                             ->children()
+                                ->scalarNode('manager_name')->defaultNull()->end()
                                 ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                             ->end()
                         ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,7 +30,6 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->canBeEnabled()
                             ->children()
-                                ->scalarNode('document_class')->defaultValue('Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent')->end()
                                 ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                             ->end()
                         ->end()

--- a/tests/Resources/Fixtures/config/config2.xml
+++ b/tests/Resources/Fixtures/config/config2.xml
@@ -2,10 +2,7 @@
     default-template="::base.html.twig">
 
     <persistence>
-        <phpcr enabled="true"
-            document-class="Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent"
-            content-basepath="/cms/content"
-        />
+        <phpcr enabled="true" content-basepath="/cms/content" />
     </persistence>
 
     <ivory-ckeditor config-name="my_custom_toolbar"/>


### PR DESCRIPTION
I had seen that `*_document_class` configuration option were removed from `symfony-cmf/block-bundle`, so I thought that change is also applicable here and I deleted `document_class` option.

I also removed processing of undefined in configuration option `manager_name`.