### PR TITLE
standardize template variable name with FrameworkBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+* **2017-02-06**: [BC BREAK] Controller excpects the template to be called 
+  `$template` and no longer `$contentTemplate`. If you use the CmfRoutingBundle,
+  you don't need to do anything as it was renamed there as well. If you extend
+  this controller or have a different routing, you need to adjust.
+
 2.0.0-RC1
 ---------
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony-cmf/core-bundle": "^1.1|^2.0",
         "symfony-cmf/menu-bundle": "^1.1|^2.0",
-        "symfony-cmf/routing-bundle": "^1.2|^2.0"
+        "symfony-cmf/routing-bundle": "^2.0"
     },
     "require-dev": {
         "doctrine/phpcr-odm": "^1.4|^2.0",

--- a/src/Controller/ContentController.php
+++ b/src/Controller/ContentController.php
@@ -18,8 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * The content controller is a simple controller that calls a template with
- * the specified content.
+ * This controller renders the content object with a template defined on the route.
  */
 class ContentController
 {
@@ -66,15 +65,15 @@ class ContentController
      *
      * @param Request $request
      * @param object  $contentDocument
-     * @param string  $contentTemplate Symfony path of the template to render
+     * @param string  $template        Symfony path of the template to render
      *                                 the content document. If omitted, the
      *                                 default template is used
      *
      * @return Response
      */
-    public function indexAction(Request $request, $contentDocument, $contentTemplate = null)
+    public function indexAction(Request $request, $contentDocument, $template = null)
     {
-        $contentTemplate = $contentTemplate ?: $this->defaultTemplate;
+        $contentTemplate = $template ?: $this->defaultTemplate;
 
         $contentTemplate = str_replace(
             ['{_format}', '{_locale}'],


### PR DESCRIPTION
together with https://github.com/symfony-cmf/routing-bundle/pull/388

if this is merged, adjust doc!