### PR TITLE
template can be empty

### DIFF
--- a/src/Controller/ContentController.php
+++ b/src/Controller/ContentController.php
@@ -48,7 +48,7 @@ class ContentController
      * @param ViewHandlerInterface $viewHandler     Optional view handler
      *                                              instance
      */
-    public function __construct(EngineInterface $templating, $defaultTemplate, ViewHandlerInterface $viewHandler = null)
+    public function __construct(EngineInterface $templating, $defaultTemplate = null, ViewHandlerInterface $viewHandler = null)
     {
         $this->templating = $templating;
         $this->defaultTemplate = $defaultTemplate;


### PR DESCRIPTION
if we do not explicitly tell this, symfony autowiring will complain that it does not know what to autowire even though we explicitly set the parameter as null

| Q             | A
| ------------- | ---
| Branch?       | only relevant for autowiring
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
