### PR TITLE
Use twig if templating is not available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
+        "symfony/templating": "^2.8 || ^3.3 || ^4.0",
+        "symfony/twig-bundle": "^2.8 || ^3.3 || ^4.0",
         "symfony-cmf/core-bundle": "^2.1",
         "symfony-cmf/menu-bundle": "^2.1",
         "symfony-cmf/routing-bundle": "^2.1"

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,9 +9,10 @@
     <services>
 
         <service id="cmf_content.controller" class="Symfony\Cmf\Bundle\ContentBundle\Controller\ContentController" public="true">
-            <argument type="service" id="templating" />
+            <argument type="service" id="templating" on-invalid="ignore"/>
             <argument>%cmf_content.default_template%</argument>
             <argument type="service" id="fos_rest.view_handler" on-invalid="ignore"/>
+            <argument type="service" id="twig" on-invalid="ignore"/>
         </service>
 
     </services>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`templating` may not be available without manual configuration, and this could be a reason why recipe for Symfony Flex may not be created. This PR fixes this.

I added `symfony/twig-bundle` to make `twig` service available; also i added `symfony/templating` because this package actualy required right (and not installed with composer).