### PR TITLE
Add symfony/validator to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
         "symfony/templating": "^2.8 || ^3.3 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.3 || ^4.0",
+        "symfony/validator": "^2.8 || ^3.3 || ^4.0",
         "symfony-cmf/core-bundle": "^2.1",
         "symfony-cmf/menu-bundle": "^2.1",
         "symfony-cmf/routing-bundle": "^2.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master", for 2.1 release
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

In https://github.com/symfony-cmf/symfony-cmf/issues/260 i tried to create minimal recipes for SymfonyCMF bundles used in `symfony-cmf/symfony-cmf`

A recipe for `symfony-cmf/content-bundle` could contain these lines:

```yaml
cmf_content:
    persistence:
        phpcr:
            enabled: true
```

With this PR `symfony/validator` package will be added to composer.json. Service `validator.builder` is used in `ValidationPass` compiler pass